### PR TITLE
environment: fix returning multifields with multiple environments

### DIFF
--- a/clipsmm/environment.cpp
+++ b/clipsmm/environment.cpp
@@ -802,7 +802,7 @@ void* Environment::get_function_context( void* env ) {
 }
 
 void Environment::set_return_values( void *env, void *rv, const Values &v ) {
-  void *mfptr = CreateMultifield(v.size());
+  void *mfptr = CreateMultifield2(env, v.size());
   for (unsigned int i = 0; i < v.size(); ++i) {
     unsigned int mfi = i + 1; // mfptr indices start at 1
     switch (v[i].type()) {


### PR DESCRIPTION
If we call CreateMultifield (without specifying an environment), the
multifield is created in the environment that is set as the current
environment, which is not necessarily the correct environment. Instead
of using CreateMultifield, call CreateMultifield2 and explicitly pass
the environment to the function.

Bug found and co-authored by @Sagre.