### PR TITLE
Adapt to CLIPS 6.31

### DIFF
--- a/clipsmm/any.h
+++ b/clipsmm/any.h
@@ -177,7 +177,7 @@ namespace CLIPS
     template<typename ValueType>
     const ValueType * any_cast(const any * operand)
     {
-        return any_cast<ValueType>(const_cast<any *>(operand));
+        return any_cast<ValueType>(operand);
     }
 
     template<typename ValueType>

--- a/clipsmm/environment.cpp
+++ b/clipsmm/environment.cpp
@@ -66,19 +66,19 @@ Environment::~Environment()
 }
 
 bool Environment::batch_evaluate( const std::string& filename ) {
-  return EnvBatchStar( m_cobj, const_cast<char*>( filename.c_str() ) );
+  return EnvBatchStar( m_cobj, filename.c_str() );
 }
 
 bool Environment::binary_load( const std::string& filename ) {
-  return EnvBload( m_cobj, const_cast<char*>( filename.c_str() ) );
+  return EnvBload( m_cobj, filename.c_str() );
 }
 
 bool Environment::binary_save( const std::string& filename ) {
-  return EnvBsave( m_cobj, const_cast<char*>( filename.c_str() ) );
+  return EnvBsave( m_cobj, filename.c_str() );
 }
 
 bool Environment::build( const std::string& construct ) {
-  return EnvBuild( m_cobj, const_cast<char*>( construct.c_str() ) );
+  return EnvBuild( m_cobj, construct.c_str() );
 }
 
 void Environment::clear( ) {
@@ -87,7 +87,7 @@ void Environment::clear( ) {
 
 int Environment::load( const std::string& filename )
 {
-  return EnvLoad( m_cobj, const_cast<char*>( filename.c_str() ) );
+  return EnvLoad( m_cobj, filename.c_str() );
 }
 
 void Environment::reset( )
@@ -97,7 +97,7 @@ void Environment::reset( )
 
 bool Environment::save( const std::string& filename )
 {
-  return EnvSave( m_cobj, const_cast<char*>( filename.c_str() ) );
+  return EnvSave( m_cobj, filename.c_str() );
 }
 
 bool Environment::is_dribble_active( ) {
@@ -110,21 +110,21 @@ bool Environment::dribble_off( ) {
 
 bool Environment::dribble_on( const std::string& filename )
 {
-  return EnvDribbleOn( m_cobj, const_cast<char*>( filename.c_str() ) );
+  return EnvDribbleOn( m_cobj, filename.c_str() );
 }
 
 int Environment::is_watched( const std::string& item ) {
-  return EnvGetWatchItem( m_cobj, const_cast<char*>( item.c_str() ) );
+  return EnvGetWatchItem( m_cobj, item.c_str() );
 }
 
 bool Environment::watch( const std::string& item )
 {
-  return EnvWatch( m_cobj, const_cast<char*>( item.c_str() ) );
+  return EnvWatch( m_cobj, item.c_str() );
 }
 
 bool Environment::unwatch( const std::string& item )
 {
-  return EnvUnwatch( m_cobj, const_cast<char*>( item.c_str() ) );
+  return EnvUnwatch( m_cobj, item.c_str() );
 }
 
 long int Environment::run( long int runlimit )
@@ -285,7 +285,7 @@ Environment::get_facts()
 DefaultFacts::pointer Environment::get_default_facts( const std::string & default_facts_name )
 {
   void* deffacts;
-  deffacts = EnvFindDeffacts( m_cobj, const_cast<char*>(default_facts_name.c_str()) );
+  deffacts = EnvFindDeffacts( m_cobj, default_facts_name.c_str() );
   if ( deffacts )
     return DefaultFacts::create( *this, deffacts );
   else
@@ -334,7 +334,7 @@ Template::pointer Environment::get_template( const std::string & template_name )
   if ( ! m_cobj )
     return Template::pointer();
 
-  void* tem = EnvFindDeftemplate( m_cobj, const_cast<char*>( template_name.c_str() ) );
+  void* tem = EnvFindDeftemplate( m_cobj, template_name.c_str() );
 
   if ( !tem )
     return Template::pointer();
@@ -382,7 +382,7 @@ Template::pointer Environment::get_template_list_head( )
 Rule::pointer Environment::get_rule( const std::string & rule_name )
 {
   void* rule;
-  rule = EnvFindDefrule( m_cobj, const_cast<char*>(rule_name.c_str()) );
+  rule = EnvFindDefrule( m_cobj, rule_name.c_str() );
   if ( rule )
     return Rule::create( *this, rule );
   else
@@ -433,7 +433,7 @@ void Environment::remove_rules( )
 
 Fact::pointer Environment::assert_fact( const std::string& factstring )
 {
-  void* clips_fact = EnvAssertString( m_cobj, const_cast<char*>(factstring.c_str()) );
+  void* clips_fact = EnvAssertString( m_cobj, factstring.c_str() );
   if ( clips_fact )
     return Fact::create( *this, clips_fact );
   else
@@ -484,7 +484,7 @@ bool Environment::use_incremental_reset( bool use )
 Module::pointer Environment::get_module( const std::string & module_name )
 {
   void* module;
-  module = EnvFindDefmodule( m_cobj, const_cast<char*>(module_name.c_str()) );
+  module = EnvFindDefmodule( m_cobj, module_name.c_str() );
   if (module)
     return Module::create( *this, module );
   else
@@ -596,7 +596,7 @@ Values Environment::evaluate( const std::string& expression )
 {
   DATA_OBJECT clipsdo;
   int result;
-  result = EnvEval( m_cobj, const_cast<char*>(expression.c_str()), &clipsdo );
+  result = EnvEval( m_cobj, expression.c_str(), &clipsdo );
   if ( result )
     return data_object_to_values( clipsdo );
   else
@@ -609,8 +609,8 @@ Values Environment::function( const std::string & function_name,
   DATA_OBJECT clipsdo;
   int result;
   result = EnvFunctionCall( m_cobj,
-                            const_cast<char*>(function_name.c_str()),
-                            const_cast<char*>(arguments.c_str()),
+                            function_name.c_str(),
+                            arguments.c_str(),
                             &clipsdo);
   if ( !result )
     return data_object_to_values( clipsdo );
@@ -620,7 +620,7 @@ Values Environment::function( const std::string & function_name,
 
 bool Environment::remove_function( std::string name )
 {
-  bool result = UndefineFunction( m_cobj, const_cast<char*>(name.c_str()) );
+  bool result = UndefineFunction( m_cobj, name.c_str() );
   m_slots.erase(name);
   if (m_func_restr.find(name) != m_func_restr.end()) {
     free(m_func_restr[name]);
@@ -630,7 +630,7 @@ bool Environment::remove_function( std::string name )
 }
 
 Global::pointer Environment::get_global( const std::string& global_name ) {
-  void* clips_global = EnvFindDefglobal( m_cobj, const_cast<char*>(global_name.c_str()));
+  void* clips_global = EnvFindDefglobal( m_cobj, global_name.c_str());
   if ( clips_global )
     return Global::create( *this, clips_global );
   else
@@ -677,7 +677,7 @@ std::vector<std::string> Environment::get_globals_names( Module::pointer module 
 }
 
 Function::pointer Environment::get_function( const std::string& function_name ) {
-  void* clips_function = EnvFindDeffunction( m_cobj, const_cast<char*>(function_name.c_str()));
+  void* clips_function = EnvFindDeffunction( m_cobj, function_name.c_str());
   if ( clips_function )
     return Function::create( *this, clips_function );
   else
@@ -817,17 +817,17 @@ void Environment::set_return_values( void *env, void *rv, const Values &v ) {
     case TYPE_SYMBOL:
       SetMFType(mfptr, mfi, SYMBOL);
       SetMFValue(mfptr, mfi,
-                 EnvAddSymbol(env, const_cast<char*>(v[i].as_string().c_str())));
+                 EnvAddSymbol(env, v[i].as_string().c_str()));
       break;
     case TYPE_STRING:
       SetMFType(mfptr, mfi, STRING);
       SetMFValue(mfptr, mfi,
-                 EnvAddSymbol(env, const_cast<char*>(v[i].as_string().c_str())));
+                 EnvAddSymbol(env, v[i].as_string().c_str()));
       break;
     case TYPE_INSTANCE_NAME:
       SetMFType(mfptr, mfi, INSTANCE_NAME);
       SetMFValue(mfptr, mfi,
-                 EnvAddSymbol(env, const_cast<char*>(v[i].as_string().c_str())));
+                 EnvAddSymbol(env, v[i].as_string().c_str()));
       break;
     case TYPE_EXTERNAL_ADDRESS:
       SetMFType(mfptr, mfi, EXTERNAL_ADDRESS);
@@ -854,7 +854,7 @@ void Environment::set_return_value( void *env, void *rv, const Value &v)
 }
 
 void* Environment::add_symbol(void *env, const char* s ) {
-  return EnvAddSymbol(env, const_cast<char*>(s) );
+  return EnvAddSymbol(env, s);
 }
 
 }

--- a/clipsmm/environment.h
+++ b/clipsmm/environment.h
@@ -46,7 +46,7 @@
 #include <clipsmm/any.h>
 
 extern "C" {
-  int EnvDefineFunction2WithContext( void *, char *, int, int ( * ) ( void * ), char *, char *, void * );
+  int EnvDefineFunction2WithContext( void *, const char *, int, int ( * ) ( void * ), const char *, const char *, void * );
 }
 
 namespace CLIPS {
@@ -1633,10 +1633,10 @@ template < typename T_return >
     any holder = CLIPSPointer<sigc::slot0<T_return> >(scb);
     m_slots[name] = holder;
     return ( EnvDefineFunction2WithContext( m_cobj,
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  retcode,
                                  get_callback(slot),
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  argstring,
                                  ( void* ) scb ) );
   }
@@ -1650,10 +1650,10 @@ template < typename T_return >
     any holder = CLIPSPointer<sigc::slot1<T_return, T_arg1> >(scb);
     m_slots[name] = holder;
     return ( EnvDefineFunction2WithContext( m_cobj,
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  retcode,
                                  get_callback(slot),
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  argstring,
                                  scb ) );
   }
@@ -1667,10 +1667,10 @@ template < typename T_return >
     any holder = CLIPSPointer<sigc::slot2<T_return, T_arg1, T_arg2> >(scb);
     m_slots[name] = holder;
     return ( EnvDefineFunction2WithContext( m_cobj,
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  retcode,
                                  get_callback(slot),
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  argstring,
                                  scb ) );
   }
@@ -1685,10 +1685,10 @@ template < typename T_return >
     any holder = CLIPSPointer<sigc::slot3<T_return,T_arg1,T_arg2,T_arg3> >(scb);
     m_slots[name] = holder;
     return ( EnvDefineFunction2WithContext( m_cobj,
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  retcode,
                                  get_callback(slot),
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  argstring,
                                  scb )
            );
@@ -1704,10 +1704,10 @@ template < typename T_return >
     any holder = CLIPSPointer<sigc::slot4<T_return,T_arg1,T_arg2,T_arg3,T_arg4> >(scb);
     m_slots[name] = holder;
     return ( EnvDefineFunction2WithContext( m_cobj,
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  retcode,
                                  get_callback(slot),
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  argstring,
                                  scb )
            );
@@ -1724,10 +1724,10 @@ template < typename T_return >
     any holder = CLIPSPointer<sigc::slot5<T_return,T_arg1,T_arg2,T_arg3,T_arg4,T_arg5> >(scb);
     m_slots[name] = holder;
     return ( EnvDefineFunction2WithContext( m_cobj,
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  retcode,
                                  get_callback(slot),
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  argstring,
                                  scb )
            );
@@ -1744,10 +1744,10 @@ template < typename T_return >
     any holder = CLIPSPointer<sigc::slot6<T_return,T_arg1,T_arg2,T_arg3,T_arg4,T_arg5,T_arg6> >(scb);
     m_slots[name] = holder;
     return ( EnvDefineFunction2WithContext( m_cobj,
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  retcode,
                                  get_callback(slot),
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  argstring,
                                  scb )
            );
@@ -1764,10 +1764,10 @@ template < typename T_return >
     any holder = CLIPSPointer<sigc::slot7<T_return,T_arg1,T_arg2,T_arg3,T_arg4,T_arg5,T_arg6,T_arg7> >(scb);
     m_slots[name] = holder;
     return ( EnvDefineFunction2WithContext( m_cobj,
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  retcode,
                                  get_callback(slot),
-                                 const_cast<char*>( name.c_str() ),
+                                 name.c_str(),
                                  argstring,
                                  scb )
            );

--- a/clipsmm/fact.cpp
+++ b/clipsmm/fact.cpp
@@ -102,7 +102,7 @@ Values Fact::slot_value( const std::string & name )
 //       result = EnvGetFactSlot( m_environment.cobj(), m_cobj, "", &data_object );
     }
     else
-  		result = EnvGetFactSlot( m_environment.cobj(), m_cobj, const_cast<char*>(name.c_str()), &data_object );
+  		result = EnvGetFactSlot( m_environment.cobj(), m_cobj, name.c_str(), &data_object );
 		if (result)
 			return data_object_to_values( data_object );
     else
@@ -143,7 +143,7 @@ bool Fact::set_slot( const std::string & slot_name, const Value & value )
   }
   bool rv = EnvPutFactSlot( m_environment.cobj(),
 			    m_cobj,
-			    const_cast<char*>(slot_name.c_str()),
+			    slot_name.c_str(),
 			    clipsdo);
   delete clipsdo;
   return rv;
@@ -158,7 +158,7 @@ bool Fact::set_slot( const std::string & slot_name, const Values & values )
   }
   bool rv = EnvPutFactSlot( m_environment.cobj(),
 			    m_cobj,
-			    const_cast<char*>(slot_name.c_str()),
+			    slot_name.c_str(),
 			    clipsdo);
   delete clipsdo;
   return rv;

--- a/clipsmm/template.cpp
+++ b/clipsmm/template.cpp
@@ -62,7 +62,7 @@ namespace CLIPS {
     if ( m_cobj ) {
       EnvDeftemplateSlotAllowedValues( m_environment.cobj(),
                                        m_cobj,
-                                       const_cast<char*>( slot_name.c_str() ),
+                                       slot_name.c_str(),
                                        &clipsdo );
       return data_object_to_values( clipsdo );
     } else
@@ -74,7 +74,7 @@ namespace CLIPS {
     if ( m_cobj ) {
       EnvDeftemplateSlotCardinality( m_environment.cobj(),
                                      m_cobj,
-                                     const_cast<char*>( slot_name.c_str() ),
+                                     slot_name.c_str(),
                                      &clipsdo );
       return data_object_to_values( clipsdo );
     } else
@@ -85,7 +85,7 @@ namespace CLIPS {
     if ( m_cobj )
       return EnvDeftemplateSlotExistP( m_environment.cobj(),
                                        m_cobj,
-                                       const_cast<char*>( slot_name.c_str() ) );
+                                       slot_name.c_str() );
     else
       return false;
   }
@@ -94,7 +94,7 @@ namespace CLIPS {
     if ( m_cobj )
       return EnvDeftemplateSlotMultiP( m_environment.cobj(),
                                        m_cobj,
-                                       const_cast<char*>( slot_name.c_str() ) );
+                                       slot_name.c_str() );
     else
       return false;
   }
@@ -103,7 +103,7 @@ namespace CLIPS {
     if ( m_cobj )
       return EnvDeftemplateSlotSingleP( m_environment.cobj(),
                                         m_cobj,
-                                        const_cast<char*>( slot_name.c_str() ) );
+                                        slot_name.c_str() );
     else
       return false;
   }
@@ -121,7 +121,7 @@ namespace CLIPS {
   DefaultType Template::slot_default_type( const std::string & slot_name ) {
     if ( !m_cobj )
       return NO_DEFAULT;
-    return ( DefaultType ) EnvDeftemplateSlotDefaultP( m_environment.cobj(), m_cobj, const_cast<char*>( slot_name.c_str() ) );
+    return ( DefaultType ) EnvDeftemplateSlotDefaultP( m_environment.cobj(), m_cobj, slot_name.c_str() );
   }
 
   Values Template::slot_default_value( const std::string & slot_name ) {
@@ -130,7 +130,7 @@ namespace CLIPS {
       return Values();
     EnvDeftemplateSlotDefaultValue( m_environment.cobj(),
                                     m_cobj,
-                                    const_cast<char*>( slot_name.c_str() ),
+                                    slot_name.c_str(),
                                     &clipsdo );
     return data_object_to_values( clipsdo );
   }
@@ -141,7 +141,7 @@ namespace CLIPS {
       return Values();
     EnvDeftemplateSlotRange( m_environment.cobj(),
                              m_cobj,
-                             const_cast<char*>( slot_name.c_str() ),
+                             slot_name.c_str(),
                              &clipsdo );
     return data_object_to_values( clipsdo );
   }

--- a/unit_tests/fact_tests.h
+++ b/unit_tests/fact_tests.h
@@ -35,7 +35,8 @@ class FactsTest : public  CppUnit::TestFixture {
     CPPUNIT_TEST( check_ordered_fact_slots );
     CPPUNIT_TEST( check_template_fact_slot_values );
     CPPUNIT_TEST( check_ordered_fact_slot_values );
-    CPPUNIT_TEST( set_template_fact_slot_values );
+    CPPUNIT_TEST( set_template_existing_fact_slot_values );
+    CPPUNIT_TEST( set_template_new_fact_slot_values );
     CPPUNIT_TEST( template_fact_retraction );
     CPPUNIT_TEST( ordered_fact_retraction );
     CPPUNIT_TEST_SUITE_END();
@@ -92,16 +93,36 @@ class FactsTest : public  CppUnit::TestFixture {
       CPPUNIT_ASSERT( values[4] == 5 );
     }
 
-    void set_template_fact_slot_values() {
-      template_fact->set_slot( "object", "C3PO" );
-      template_fact->set_slot( "location", "Millenium Falcon" );
+    void set_template_new_fact_slot_values() {
+      Template::pointer templ = environment.get_template("in");
+      CPPUNIT_ASSERT(templ);
+      Fact::pointer new_fact = Fact::create(environment, templ);
+      CPPUNIT_ASSERT(new_fact);
+      CPPUNIT_ASSERT(new_fact->set_slot( "object", Value("C3PO", TYPE_SYMBOL)));
+      CPPUNIT_ASSERT(new_fact->set_slot( "location", Value("Millenium Falcon", TYPE_SYMBOL)));
+      Fact::pointer asserted_fact = environment.assert_fact(new_fact);
+      CPPUNIT_ASSERT(asserted_fact);
+      Values values;
+      values = asserted_fact->slot_value("object");
+      CPPUNIT_ASSERT( values.size() == 1 );
+      CPPUNIT_ASSERT_MESSAGE(std::string(values[0]), values[0] == "C3PO" );
+      values = asserted_fact->slot_value("location");
+      CPPUNIT_ASSERT( values.size() == 1 );
+      CPPUNIT_ASSERT_MESSAGE(std::string(values[0]), values[0] == "Millenium Falcon" );
+    }
+
+    void set_template_existing_fact_slot_values() {
+      // Modifying an existing fact does not work.
+      CPPUNIT_ASSERT(!template_fact->set_slot( "object", Value("C3PO", TYPE_SYMBOL)));
+      CPPUNIT_ASSERT(!template_fact->set_slot( "location", Value("Millenium Falcon", TYPE_SYMBOL)));
       Values values;
       values = template_fact->slot_value("object");
       CPPUNIT_ASSERT( values.size() == 1 );
-      CPPUNIT_ASSERT( values[0] == "C3PO" );
+      // The slot values have not changed.
+      CPPUNIT_ASSERT_MESSAGE(std::string(values[0]), values[0] == "R2D2" );
       values = template_fact->slot_value("location");
       CPPUNIT_ASSERT( values.size() == 1 );
-      CPPUNIT_ASSERT( values[0] == "Millenium Falcon" );
+      CPPUNIT_ASSERT_MESSAGE(std::string(values[0]), values[0] == "X-Wing" );
     }
 
     void template_fact_retraction() {


### PR DESCRIPTION
CLIPS 6.31 comes with two changes that require some adaptions:
* string arguments are now taken as `const char *` and not as `char *` anymore. Thus, there is no need to `const_cast` strings and we can just use `const char *` everywhere
* CLIPS no longer accepts modifications to facts that have already been asserted. This affects the function `set_slot`, which no longer works on existing facts. This may break downstream applications if they rely on the old behavior. Adapt and extend the tests to demonstrate the new behavior.